### PR TITLE
feat(Rendering): Add support for 16bit normalized 3D texture formats

### DIFF
--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -72,6 +72,7 @@ const DEFAULT_VALUES = {
   autoAdjustSampleDistances: true,
   blendMode: BlendMode.COMPOSITE_BLEND,
   ipScalarRange: [-1000000.0, 1000000.0],
+  useExperimentalNorm16Texture: false,
 };
 
 // ----------------------------------------------------------------------------
@@ -91,6 +92,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'maximumSamplesPerRay',
     'autoAdjustSampleDistances',
     'blendMode',
+    'useExperimentalNorm16Texture',
   ]);
 
   macro.setGetArray(publicAPI, model, ['ipScalarRange'], 2);

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -431,6 +431,8 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
   publicAPI.getDefaultTextureInternalFormat = (vtktype, numComps, useFloat) => {
     if (model.webgl2) {
+      const ext = model.context.getExtension('EXT_texture_norm16');
+
       switch (vtktype) {
         case VtkDataTypes.UNSIGNED_CHAR:
           switch (numComps) {
@@ -443,6 +445,30 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
             case 4:
             default:
               return model.context.RGBA8;
+          }
+        case VtkDataTypes.UNSIGNED_SHORT:
+          switch (numComps) {
+            case 1:
+              return ext.R16_EXT;
+            case 2:
+              return ext.RG16_EXT;
+            case 3:
+              return ext.RGB16_EXT;
+            case 4:
+            default:
+              return ext.RGBA16_EXT;
+          }
+        case VtkDataTypes.SHORT:
+          switch (numComps) {
+            case 1:
+              return ext.R16_SNORM_EXT;
+            case 2:
+              return ext.RG16_SNORM_EXT;
+            case 3:
+              return ext.RGB16_SNORM_EXT;
+            case 4:
+            default:
+              return ext.RGBA16_SNORM_EXT;
           }
         default:
         case VtkDataTypes.FLOAT:

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1378,7 +1378,8 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         dims[2],
         numComp,
         scalars.getDataType(),
-        scalars.getData()
+        scalars.getData(),
+        model.renderable.getUseExperimentalNorm16Texture()
       );
       // console.log(model.scalarTexture.get());
       model.scalarTextureString = toString;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [ ] All tests complete without errors on the following environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!-- Remove the line below if it is not relevant -->
_This contribution is funded by [Example](https://example.com)._
